### PR TITLE
将transient改为wp_cache储存缓存

### DIFF
--- a/class.json.php
+++ b/class.json.php
@@ -433,19 +433,19 @@ class HermitJson
 
     public function get_cache($key)
     {
-        $cache = get_transient($key);
+        $cache = wp_cache_get( $key, 'hermitx' );
         return $cache === false ? false : json_decode($cache, true);
     }
 
     public function set_cache($key, $value, $hour = 0.1)
     {
         $value = json_encode($value);
-        set_transient($key, $value, 60 * 60 * $hour);
+        wp_cache_set( $key, $value, 'hermitx', 60 * 60 * $hour );
     }
 
     public function clear_cache($key)
     {
-        //delete_transient($key);
+        //wp_cache_delete($key, 'hermitx');
     }
 
     /**

--- a/hermit.php
+++ b/hermit.php
@@ -3,13 +3,13 @@
 Plugin Name: Hermit X
 Plugin URI: https://blog.lwl12.com/read/hermit-x.html
 Description: 音乐播放器 Hermit music player build for wordpress with APlayer
-Version: 2.9.4
+Version: 2.9.5
 Author: Hermit X Developer Team
 Author URI: https://blog.lwl12.com/read/hermit-x.html#developer
 */
 
 define('HERMIT_FILE', __FILE__);
-define('HERMIT_VERSION', '2.9.4');
+define('HERMIT_VERSION', '2.9.5');
 define('HERMIT_URL', plugins_url('', __FILE__));
 define('HERMIT_PATH', dirname(__FILE__));
 define('HERMIT_ADMIN_URL', admin_url());


### PR DESCRIPTION
transient缓存过期不会自动清理，会对wp_options表照成很大负担，每次请求瞬态缓存WP都去从对象缓存里读取整个wp_options表。